### PR TITLE
add Automatic-Module-Name so that identically named artifactIds (such as core in httpmate, mapmate, message-mate) still get a distinct fully qualified java module name, allowing them to be loaded at all simultaneously in modularized java projects. This change requires each of the *mate library to be released against the new parent to make the change effective.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
     <packaging>pom</packaging>
     <groupId>com.envimate</groupId>
     <artifactId>envimate-opensource-parent</artifactId>
-    <version>1.0.20</version>
+    <version>1.0.21</version>
     <name>Envimate OpenSource java standards</name>
     <description>
         This parent pom is supposed to be used as a parent for all envimate open source projects to reliably enable
@@ -183,6 +183,18 @@
                             </configuration>
                         </execution>
                     </executions>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-jar-plugin</artifactId>
+                    <configuration>
+                        <archive>
+                            <manifestEntries>
+                                <Automatic-Module-Name>${project.groupId}.${project.artifactId}</Automatic-Module-Name>
+                            </manifestEntries>
+                        </archive>
+                    </configuration>
+
                 </plugin>
             </plugins>
         </pluginManagement>


### PR DESCRIPTION
More info at: https://dzone.com/articles/automatic-module-name-calling-all-java-library-maintainers